### PR TITLE
Rewrite package release monitoring to use thoth-python

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ thoth-common = "*"
 requests = "*"
 prometheus-client = "*"
 pyyaml = "==3.12"
+thoth-python = "*"
 
 [dev-packages]
 coala = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0ed7378c0cf8b9fbdc423de4bd99b709392f93a02f20e175981bb0b07b062732"
+            "sha256": "ea925eea9fe2f588a716dde9b1bbff1d5810840ac3b53f4ebb424c485ac7452e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -64,19 +64,34 @@
             ],
             "version": "==3.0.1"
         },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
+        },
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:194ec62a25438adcb3fdb06378b26559eda1ea8a747367d34c33cef9c7f48d57",
+                "sha256:90f8e61121d6ae58362ce3bed8cd997efb00c914eae0ff3d363c32f9a9822d10",
+                "sha256:f0abd31228055d698bb392a826528ea08ebb9959e6bea17c606fd9c9009db938"
+            ],
+            "version": "==4.6.3"
+        },
         "boto3": {
             "hashes": [
-                "sha256:4ffe3214bfa8993fcc957c9528073ddf73125c6c7a18bb17143470bccecb7d13",
-                "sha256:b36df47ca517b7c2dcb981357fa255ff9460b6c70a5143e962b98f695fc3b729"
+                "sha256:63cd957ba663f5c10ff48ed904575eaa701314f79f18dbc59bd050311cd5f809",
+                "sha256:d1338582bc58741f54bd6b43488de6097a82ea45cebed0a3fd936981eadbb3a5"
             ],
-            "version": "==1.9.83"
+            "version": "==1.9.86"
         },
         "botocore": {
             "hashes": [
-                "sha256:23eab3b3c59a3581eb8478774177e9f4cdb5edf7bf7bb26d02e22c50b2e6e469",
-                "sha256:97026101d5a9aebdd1f1f1794a25ac5fbf5969823590ee1461fb0103bc796c33"
+                "sha256:24444e7580f0114c3e9fff5d2032c6f0cfbf88691b1be3ba27c6922507a902ec",
+                "sha256:5b01a16f02c3da55068b3aacfa1c37dd8e17141551e1702424b38dd21fa1c792"
             ],
-            "version": "==1.12.83"
+            "version": "==1.12.86"
         },
         "certifi": {
             "hashes": [
@@ -99,6 +114,13 @@
             ],
             "index": "pypi",
             "version": "==7.0"
+        },
+        "contoml": {
+            "hashes": [
+                "sha256:2353275caef3726131c4192379252cc48eb4a15c06df3e1046f783de937eba94",
+                "sha256:f62960b57a9489187653787bd67756d15a79e4579c7d779d8b94f581dd260a7d"
+            ],
+            "version": "==0.32"
         },
         "cython": {
             "hashes": [
@@ -140,6 +162,20 @@
             ],
             "version": "==1.5.0"
         },
+        "delegator.py": {
+            "hashes": [
+                "sha256:814657d96b98a244c479e3d5f6e9e850ac333e85f807d6bc846e72bbb2537806",
+                "sha256:e6cc9cedab9ae59b169ee0422e17231adedadb144e63c0b5a60e6ff8adf8521b"
+            ],
+            "version": "==0.1.1"
+        },
+        "distro": {
+            "hashes": [
+                "sha256:224041cef9600e72d19ae41ba006e71c05c4dc802516da715d7fda55ba3d8742",
+                "sha256:6ec8e539cf412830e5ccf521aecf879f2c7fcf60ce446e33cd16eef1ed8a0158"
+            ],
+            "version": "==1.3.0"
+        },
         "docutils": {
             "hashes": [
                 "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
@@ -175,12 +211,51 @@
             ],
             "version": "==0.3.1"
         },
+        "iso8601": {
+            "hashes": [
+                "sha256:210e0134677cc0d02f6028087fee1df1e1d76d372ee1db0bf30bf66c5c1c89a3",
+                "sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82",
+                "sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd"
+            ],
+            "version": "==0.1.12"
+        },
         "jmespath": {
             "hashes": [
                 "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64",
                 "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"
             ],
             "version": "==0.9.3"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:0dd6589fa75d369ba06d2b5f38dae107f76ea127f212f6a7bee134f6df2d1d21",
+                "sha256:1afbac344aa68c29e81ab56c1a9411c3663157b5aee5065b7fa030b398d4f7e0",
+                "sha256:1baad9d073692421ad5dbbd81430aba6c7f5fdc347f03537ae046ddf2c9b2297",
+                "sha256:1d8736421a2358becd3edf20260e41a06a0bf08a560480d3a5734a6bcbacf591",
+                "sha256:1e1d9bddc5afaddf0de76246d3f2152f961697ad7439c559f179002682c45801",
+                "sha256:1f179dc8b2643715f020f4d119d5529b02cd794c1c8f305868b73b8674d2a03f",
+                "sha256:241fb7bdf97cb1df1edfa8f0bcdfd80525d4023dac4523a241907c8b2f44e541",
+                "sha256:2f9765ee5acd3dbdcdc0d0c79309e01f7c16bc8d39b49250bf88de7b46daaf58",
+                "sha256:312e1e1b1c3ce0c67e0b8105317323e12807955e8186872affb667dbd67971f6",
+                "sha256:3273db1a8055ca70257fd3691c6d2c216544e1a70b673543e15cc077d8e9c730",
+                "sha256:34dfaa8c02891f9a246b17a732ca3e99c5e42802416628e740a5d1cb2f50ff49",
+                "sha256:3aa3f5288af349a0f3a96448ebf2e57e17332d99f4f30b02093b7948bd9f94cc",
+                "sha256:51102e160b9d83c1cc435162d90b8e3c8c93b28d18d87b60c56522d332d26879",
+                "sha256:56115fc2e2a4140e8994eb9585119a1ae9223b506826089a3ba753a62bd194a6",
+                "sha256:69d83de14dbe8fe51dccfd36f88bf0b40f5debeac763edf9f8325180190eba6e",
+                "sha256:99fdce94aeaa3ccbdfcb1e23b34273605c5853aa92ec23d84c84765178662c6c",
+                "sha256:a7c0cd5b8a20f3093ee4a67374ccb3b8a126743b15a4d759e2a1bf098faac2b2",
+                "sha256:abe12886554634ed95416a46701a917784cb2b4c77bfacac6916681d49bbf83d",
+                "sha256:b4f67b5183bd5f9bafaeb76ad119e977ba570d2b0e61202f534ac9b5c33b4485",
+                "sha256:bdd7c1658475cc1b867b36d5c4ed4bc316be8d3368abe03d348ba906a1f83b0e",
+                "sha256:c6f24149a19f611a415a51b9bc5f17b6c2f698e0d6b41ffb3fa9f24d35d05d73",
+                "sha256:d1e111b3ab98613115a208c1017f266478b0ab224a67bc8eac670fa0bad7d488",
+                "sha256:d6520aa965773bbab6cb7a791d5895b00d02cf9adc93ac2bf4edb9ac1a6addc5",
+                "sha256:dd185cde2ccad7b649593b0cda72021bc8a91667417001dbaf24cd746ecb7c11",
+                "sha256:de2e5b0828a9d285f909b5d2e9d43f1cf6cf21fe65bc7660bdaa1780c7b58298",
+                "sha256:f726444b8e909c4f41b4fde416e1071cf28fa84634bfb4befdf400933b6463af"
+            ],
+            "version": "==4.3.0"
         },
         "multidict": {
             "hashes": [
@@ -216,12 +291,26 @@
             ],
             "version": "==4.5.2"
         },
+        "pexpect": {
+            "hashes": [
+                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
+                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
+            ],
+            "version": "==4.6.0"
+        },
         "prometheus-client": {
             "hashes": [
                 "sha256:e8c11ff5ca53de6c3d91e1510500611cafd1d247a937ec6c588a0a7cc3bef93c"
             ],
             "index": "pypi",
             "version": "==0.5.0"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "version": "==0.6.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -274,6 +363,13 @@
             ],
             "version": "==0.1.13"
         },
+        "semantic-version": {
+            "hashes": [
+                "sha256:2a4328680073e9b243667b201119772aefc5fc63ae32398d6afafff07c4f54c0",
+                "sha256:2d06ab7372034bcb8b54f2205370f4aa0643c133b7e6dbd129c5200b83ab394b"
+            ],
+            "version": "==2.6.0"
+        },
         "sentry-sdk": {
             "hashes": [
                 "sha256:78bb79adfe991a770ce2179826f5f216e086bbc4bd4585c543f377180cae3654",
@@ -288,6 +384,19 @@
             ],
             "version": "==1.10.0"
         },
+        "strict-rfc3339": {
+            "hashes": [
+                "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277"
+            ],
+            "version": "==0.7"
+        },
+        "thoth-analyzer": {
+            "hashes": [
+                "sha256:607b050b84fb21cafae56c29703e179b9326d63f76f87e20b25c7e708f3dcf30",
+                "sha256:f9cda99a582fab64924a4b8bd5dae3b47349ae3486d37023147235a22e896e56"
+            ],
+            "version": "==0.1.0"
+        },
         "thoth-common": {
             "hashes": [
                 "sha256:74c4ee049e4403198031bb7fbe8288d546db823aa1c4bcab408506f23224cd73",
@@ -296,6 +405,13 @@
             "index": "pypi",
             "version": "==0.6.0"
         },
+        "thoth-python": {
+            "hashes": [
+                "sha256:b6f04cc4612ad069005612d730a03dfae44df2a36ba75c82398ecc96b2c43ba8"
+            ],
+            "index": "pypi",
+            "version": "==0.4.6"
+        },
         "thoth-storages": {
             "hashes": [
                 "sha256:73a713dcd387d2a1354741fed3f492c29473d921553627180817481fa4ce7f11",
@@ -303,6 +419,12 @@
             ],
             "index": "pypi",
             "version": "==0.9.5"
+        },
+        "timestamp": {
+            "hashes": [
+                "sha256:b5c7a4539f0d8742b7d6c78febd241ab24903c73c38045690725220ca7eae4ac"
+            ],
+            "version": "==0.0.1"
         },
         "tornado": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
 
 from thoth.common import init_logging
 from thoth.python import Source
+from thoth.python.exceptions import NotFound
 from thoth.storages import GraphDatabase
 from thoth.storages import __version__ as thoth_storages_version
 
@@ -133,6 +134,9 @@ def package_releases_update(
         for package_name in package_index.get_packages():
             try:
                 package_versions = package_index.get_package_versions(package_name)
+            except NotFound as exc:
+                _LOGGER.warning("No versions found for package %r: %s", package_name, str(exc))
+                continue
             except Exception as exc:
                 _LOGGER.exception("Failed to retrieve package versions for %r: %s", package_name, str(exc))
                 continue

--- a/app.py
+++ b/app.py
@@ -34,22 +34,29 @@ from thoth.storages import __version__ as thoth_storages_version
 
 
 # Reuse thoth-storages version as we rely on it.
-__version__ = '0.6.0' + '+thoth_storage.' + thoth_storages_version
+__version__ = "0.6.0" + "+thoth_storage." + thoth_storages_version
 
 
 init_logging()
 
-_LOGGER = logging.getLogger('thoth.package_releases')
-_PUSH_GATEWAY_HOST = os.getenv('PROMETHEUS_PUSHGATEWAY_HOST')
-_PUSH_GATEWAY_PORT = os.getenv('PROMETHEUS_PUSHGATEWAY_PORT')
+_LOGGER = logging.getLogger("thoth.package_releases")
+_PUSH_GATEWAY_HOST = os.getenv("PROMETHEUS_PUSHGATEWAY_HOST")
+_PUSH_GATEWAY_PORT = os.getenv("PROMETHEUS_PUSHGATEWAY_PORT")
 
 prometheus_registry = CollectorRegistry()
 _METRIC_PACKAGES_NEW_AND_ADDED = Gauge(
-    'packages_added', 'Packages newly added', registry=prometheus_registry)
+    "packages_added", "Packages newly added", registry=prometheus_registry
+)
 _METRIC_PACKAGES_NEW_AND_NOTIFIED = Gauge(
-    'packages_notified', 'Packages newly added and notification send', registry=prometheus_registry)
+    "packages_notified",
+    "Packages newly added and notification send",
+    registry=prometheus_registry,
+)
 _METRIC_PACKAGES_RELEASES_TIME = Gauge(
-    'package_releases_time', 'Runtime of package releases job', registry=prometheus_registry)
+    "package_releases_time",
+    "Runtime of package releases job",
+    registry=prometheus_registry,
+)
 
 
 def _print_version(ctx, _, value):
@@ -65,44 +72,60 @@ def _load_package_monitoring_config(config_path: str) -> typing.Optional[dict]:
     if not config_path:
         return None
 
-    if config_path.startswith(('https://', 'http://')):
+    if config_path.startswith(("https://", "http://")):
         _LOGGER.debug(f"Loading remote monitoring config from {config_path}")
         content = requests.get(config_path)
         content.raise_for_status()
         content = content.text
     else:
         _LOGGER.debug(f"Loading local monitoring config from {config_path}")
-        with open(config_path, 'r') as config_file:
+        with open(config_path, "r") as config_file:
             content = config_file.read()
 
     return yaml.load(content)
 
 
-def release_notification(monitored_packages: dict, package_name: str, package_version: str) -> bool:
+def release_notification(
+    monitored_packages: dict, package_name: str, package_version: str
+) -> bool:
     """Check for release notification in monitoring configuration and trigger notification if requested."""
     was_triggered = False
-    for trigger in monitored_packages.get(package_name, {}).get('triggers') or []:
-        _LOGGER.debug(f"Triggering release notification for {package_name} ({package_version})")
+    for trigger in monitored_packages.get(package_name, {}).get("triggers") or []:
+        _LOGGER.debug(
+            f"Triggering release notification for {package_name} ({package_version})"
+        )
         try:
             # We expand URL based on environment variables, package name and package version so a user can fully
             # configure what should be present in the URL.
             response = requests.post(
-                trigger['url'].format(**os.environ, package_name=package_name, package_version=package_version),
-                verify=trigger.get('tls_verify', True)
+                trigger["url"].format(
+                    **os.environ,
+                    package_name=package_name,
+                    package_version=package_version,
+                ),
+                verify=trigger.get("tls_verify", True),
             )
             response.raise_for_status()
             was_triggered = True
             _LOGGER.info(
                 f"Successfully triggered release notification for {package_name} "
-                f"({package_version}) to {trigger['url']}")
+                f"({package_version}) to {trigger['url']}"
+            )
         except Exception as exc:
-            _LOGGER.exception(f"Failed to trigger release notification for {package_name} "
-                              f"({package_version}) for trigger {trigger}, error is not fatal: {str(exc)}")
+            _LOGGER.exception(
+                f"Failed to trigger release notification for {package_name} "
+                f"({package_version}) for trigger {trigger}, error is not fatal: {str(exc)}"
+            )
 
     return was_triggered
 
 
-def package_releases_update(monitored_packages: dict, *, graph: GraphDatabase, only_if_package_seen: bool = False):
+def package_releases_update(
+    monitored_packages: dict,
+    *,
+    graph: GraphDatabase,
+    only_if_package_seen: bool = False,
+):
     """Check for updates of packages, notify about updates if configured so."""
     sources = [Source(**config) for config in graph.python_package_index_listing()]
 
@@ -113,13 +136,15 @@ def package_releases_update(monitored_packages: dict, *, graph: GraphDatabase, o
                     package_name,
                     package_version,
                     package_index.url,
-                    only_if_package_seen=only_if_package_seen
+                    only_if_package_seen=only_if_package_seen,
                 )
 
                 if added is None:
                     _LOGGER.info(
                         "Package %r in version %r hosted on %r was not added - it was not previously seen",
-                        package_name, package_version, package_index.url
+                        package_name,
+                        package_version,
+                        package_index.url,
                     )
                     continue
 
@@ -127,40 +152,64 @@ def package_releases_update(monitored_packages: dict, *, graph: GraphDatabase, o
                 if not existed:
                     _LOGGER.info(
                         "New release of package %r in version %r hosted on %r added",
-                        package_name, package_version, package_index.url
+                        package_name,
+                        package_version,
+                        package_index.url,
                     )
                     _METRIC_PACKAGES_NEW_AND_ADDED.inc()
                 else:
                     _LOGGER.debug(
                         "Release of %r in version %r hosted on %r already present",
-                        package_name, package_version, package_index.url
+                        package_name,
+                        package_version,
+                        package_index.url,
                     )
 
                 if added and monitored_packages:
                     try:
-                        release_notification(monitored_packages, package_name, package_version)
+                        release_notification(
+                            monitored_packages, package_name, package_version
+                        )
                         _METRIC_PACKAGES_NEW_AND_NOTIFIED.inc()
                     except Exception as exc:
                         _LOGGER.exception(
                             f"Failed to do release notification for {package_name} ({package_version}), "
-                            f"error is not fatal: {str(exc)}")
+                            f"error is not fatal: {str(exc)}"
+                        )
 
 
 @click.command()
 @click.pass_context
-@click.option('-v', '--verbose', is_flag=True,
-              help="Be verbose about what's going on.")
-@click.option('--version', is_flag=True, is_eager=True, callback=_print_version, expose_value=False,
-              help="Print version and exit.")
-@click.option('--monitoring-config', '-m', type=str, show_default=True, metavar='CONFIG',
-              envvar='THOTH_PACKAGE_RELEASES_MONITORING_CONFIG',
-              help="PyPI RSS feed to be used.")
-@click.option('--only-if-package-seen', is_flag=True, envvar='THOTH_PACKAGE_RELEASES_ONLY_IF_PACKAGE_SEEN',
-              help="Create entries only for packages for which entries already exist in the graph database.")
-def cli(ctx=None, verbose=False, monitoring_config: str = None, only_if_package_seen=False):
+@click.option("-v", "--verbose", is_flag=True, help="Be verbose about what's going on.")
+@click.option(
+    "--version",
+    is_flag=True,
+    is_eager=True,
+    callback=_print_version,
+    expose_value=False,
+    help="Print version and exit.",
+)
+@click.option(
+    "--monitoring-config",
+    "-m",
+    type=str,
+    show_default=True,
+    metavar="CONFIG",
+    envvar="THOTH_PACKAGE_RELEASES_MONITORING_CONFIG",
+    help="PyPI RSS feed to be used.",
+)
+@click.option(
+    "--only-if-package-seen",
+    is_flag=True,
+    envvar="THOTH_PACKAGE_RELEASES_ONLY_IF_PACKAGE_SEEN",
+    help="Create entries only for packages for which entries already exist in the graph database.",
+)
+def cli(
+    ctx=None, verbose=False, monitoring_config: str = None, only_if_package_seen=False
+):
     """Check for updates in PyPI RSS feed and add missing entries to the graph database."""
     if ctx:
-        ctx.auto_envvar_prefix = 'THOTH_PACKAGE_RELEASES'
+        ctx.auto_envvar_prefix = "THOTH_PACKAGE_RELEASES"
 
     if verbose:
         _LOGGER.setLevel(logging.DEBUG)
@@ -176,21 +225,31 @@ def cli(ctx=None, verbose=False, monitoring_config: str = None, only_if_package_
         try:
             monitored_packages = _load_package_monitoring_config(monitoring_config)
         except Exception:
-            _LOGGER.exception(f"Failed to load monitoring configuration from {monitoring_config}")
+            _LOGGER.exception(
+                f"Failed to load monitoring configuration from {monitoring_config}"
+            )
             raise
 
     try:
         with _METRIC_PACKAGES_RELEASES_TIME.time():
-            package_releases_update(monitored_packages, graph=graph, only_if_package_seen=only_if_package_seen)
+            package_releases_update(
+                monitored_packages,
+                graph=graph,
+                only_if_package_seen=only_if_package_seen,
+            )
     finally:
         if _PUSH_GATEWAY_HOST and _PUSH_GATEWAY_PORT:
             try:
                 push_gateway = f"{_PUSH_GATEWAY_HOST}:{_PUSH_GATEWAY_PORT}"
-                _LOGGER.info(f"Submitting metrics to Prometheus push gateway {push_gateway}")
-                push_to_gateway(push_gateway, job='package-releases', registry=prometheus_registry)
+                _LOGGER.info(
+                    f"Submitting metrics to Prometheus push gateway {push_gateway}"
+                )
+                push_to_gateway(
+                    push_gateway, job="package-releases", registry=prometheus_registry
+                )
             except Exception as e:
-                _LOGGER.exception(f'An error occurred pushing the metrics: {str(e)}')
+                _LOGGER.exception(f"An error occurred pushing the metrics: {str(e)}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/app.py
+++ b/app.py
@@ -140,7 +140,7 @@ def package_releases_update(
                 )
 
                 if added is None:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "Package %r in version %r hosted on %r was not added - it was not previously seen",
                         package_name,
                         package_version,

--- a/app.py
+++ b/app.py
@@ -131,7 +131,13 @@ def package_releases_update(
 
     for package_index in sources:
         for package_name in package_index.get_packages():
-            for package_version in package_index.get_package_versions(package_name):
+            try:
+                package_versions = package_index.get_package_versions(package_name)
+            except Exception as exc:
+                _LOGGER.exception("Failed to retrieve package versions for %r: %s", package_name, str(exc))
+                continue
+
+            for package_version in package_versions:
                 added = graph.create_pypi_package_version(
                     package_name,
                     package_version,

--- a/app.py
+++ b/app.py
@@ -116,7 +116,15 @@ def package_releases_update(monitored_packages: dict, *, graph: GraphDatabase, o
                     only_if_package_seen=only_if_package_seen
                 )
 
-                if added:
+                if added is None:
+                    _LOGGER.info(
+                        "Package %r in version %r hosted on %r was not added - it was not previously seen",
+                        package_name, package_version, package_index.url
+                    )
+                    continue
+
+                existed = added[0]
+                if not existed:
                     _LOGGER.info(
                         "New release of package %r in version %r hosted on %r added",
                         package_name, package_version, package_index.url
@@ -124,7 +132,7 @@ def package_releases_update(monitored_packages: dict, *, graph: GraphDatabase, o
                     _METRIC_PACKAGES_NEW_AND_ADDED.inc()
                 else:
                     _LOGGER.debug(
-                        "Not added release of %r in version %r hosted on %r",
+                        "Release of %r in version %r hosted on %r already present",
                         package_name, package_version, package_index.url
                     )
 

--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -33,7 +33,7 @@ objects:
         app: thoth
         component: package-releases
     spec:
-      schedule: '*/30 * * * *'
+      schedule: '*/60 * * * *'
       suspend: ${{THOTH_SUSPEND_JOB}}
       concurrencyPolicy: Forbid
       successfulJobsHistoryLimit: 4

--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -33,7 +33,7 @@ objects:
         app: thoth
         component: package-releases
     spec:
-      schedule: '*/60 * * * *'
+      schedule: '0 */6 * * *'
       suspend: ${{THOTH_SUSPEND_JOB}}
       concurrencyPolicy: Forbid
       successfulJobsHistoryLimit: 4

--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -33,7 +33,7 @@ objects:
         app: thoth
         component: package-releases
     spec:
-      schedule: '*/6 * * * *'
+      schedule: '*/30 * * * *'
       suspend: ${{THOTH_SUSPEND_JOB}}
       concurrencyPolicy: Forbid
       successfulJobsHistoryLimit: 4


### PR DESCRIPTION
This way we drop RSS feed checking and rather rely on REST API or Simple API
that is exposed based on PEEP. We monitor all the packages and we are not
limited to RSS feed updates. Also with this patch we transparently monitor all
package indexes known to Thoth.

Closes: #84 