### PR TITLE
Update the trigger-build job to use the latest job API

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,7 +10,9 @@
       jobs:
         - trigger-build:
             vars:
-              webhook_url: https://paas.upshift.redhat.com/oapi/v1/namespaces/thoth-test-core/buildconfigs/package-releases-job
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "package-releases-job"
     kebechet-auto-gate:
       queue: "thoth-station/core"
       jobs:

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -57,6 +57,10 @@ objects:
         - type: ConfigChange
         - type: ImageChange
           imageChange: {}
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret
 
 parameters:
   - description: Name of the github repository for Thoth's Package Releases Job


### PR DESCRIPTION
Update buildconfig template to allow the buildconfig listen to generic webhook and update the zuul config file to use the latest version of trigger-build job API.