### PR TITLE
Use Python package version entity names as a base for known Python packages

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,7 +148,7 @@ def package_releases_update(
     if only_if_package_seen:
         # An optimization - we don't need to iterate over a large set present on index.
         # Check only packages known to Thoth.
-        package_names = graph.get_python_package_names_all(distinct=True)
+        package_names = graph.get_python_package_version_entities_names_all()
 
     for package_index in sources:
         _LOGGER.info("Checking index %r for new package releases", package_index.url)


### PR DESCRIPTION
Related: https://github.com/thoth-station/storages/pull/1485