### PR TITLE
Manual update of dependency thoth-messaging from 0.7.3 to 0.7.6

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -100,17 +100,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:2bead722a2b91d11faad0479eadf57283c864a40687100d0f5829e6a4242ccb1",
-                "sha256:74e0058e373d64e23dea639fc7bcd3d83d08e091a044f32513d13cc4a03d7fe5"
+                "sha256:28bf1bce2979d4d1674d63b1b4d6ac30b6844b5d3604e69d8847b18602588861",
+                "sha256:78f3ebcdff149d5327f27a5c461a9e394306b7db9a60e8bd65c9401cc41d99d3"
             ],
-            "version": "==1.14.62"
+            "version": "==1.15.0"
         },
         "botocore": {
             "hashes": [
-                "sha256:8712b69f6e4abd9a5ef52b20fb5b9ca545cda335ee1b106fc68dd7786c7c78ae",
-                "sha256:a47ec927517403c6711f0cf7c51207f45b5aa4875791527a395a6402bd146514"
+                "sha256:1dbd37af06432eda8a5736bd82f92ddd1ae8de74e4faa090bd728f8d58d24849",
+                "sha256:f3d509f06201582e60523263d52016b50415461bc6a03afb5434f477a1de3ba0"
             ],
-            "version": "==1.17.62"
+            "version": "==1.18.0"
         },
         "cachetools": {
             "hashes": [
@@ -201,14 +201,6 @@
                 "sha256:df74eed763e18d10d0da624258524ae80486432cd17392d9c3d96f5e83cd2799"
             ],
             "version": "==1.5.0"
-        },
-        "docutils": {
-            "hashes": [
-                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
-                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
-                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
-            ],
-            "version": "==0.15.2"
         },
         "faust": {
             "hashes": [
@@ -754,11 +746,11 @@
         },
         "thoth-messaging": {
             "hashes": [
-                "sha256:4a677319d04f2703e867f2b9d065774a60c2029c282eee5d1840a7bd23662481",
-                "sha256:c1a7545f845f2317c83cc99cc88253e3ea398023c06e45710d8a6a4c84d447e7"
+                "sha256:38f7d60e4e83746db31dce49aee701d08b8efcdf50f56fc9c6d302b5a1888103",
+                "sha256:b6b10a2f28d430b188950a96ba257d886a33a35baa2ca4b168dff7ce5d64fef9"
             ],
             "index": "pypi",
-            "version": "==0.7.3"
+            "version": "==0.7.6"
         },
         "thoth-python": {
             "hashes": [


### PR DESCRIPTION
Dependency thoth-messaging was used in version 0.7.3, but the current latest version is 0.7.6.