### PR TITLE
Rewrite to use asyncio for more optimal new releases retrieval

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,10 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-requests = "*"
 pyyaml = "*"
 thoth-storages = "*"
 thoth-common = "*"
 thoth-python = "*"
-jsonpath-ng = "*"
 prometheus-client = "*"
 thoth-messaging = "*"
 click = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1f4544ccbca499f31ea089721997c1b292975d96bfb6e76077160948707c5d94"
+            "sha256": "7612d1309e81410d24f9b160ac114e146521d2289dbe2e7c7ea1278aa678c3a0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -104,6 +104,28 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
+        "backports.zoneinfo": {
+            "hashes": [
+                "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf",
+                "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328",
+                "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546",
+                "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6",
+                "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570",
+                "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9",
+                "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7",
+                "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987",
+                "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722",
+                "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582",
+                "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc",
+                "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b",
+                "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1",
+                "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08",
+                "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac",
+                "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==0.2.1"
+        },
         "beautifulsoup4": {
             "hashes": [
                 "sha256:194ec62a25438adcb3fdb06378b26559eda1ea8a747367d34c33cef9c7f48d57",
@@ -114,19 +136,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:a012570d3535ec6c4db97e60ef51c2f39f38246429e1455cecc26c633ed81c10",
-                "sha256:c7f45b0417395d3020c98cdc10f942939883018210e29dbfe6fbfc0a74e503ec"
+                "sha256:39ed0f5004b671e4a4241ae23023ad63674cd25f766bfe1617cfc809728bc3e0",
+                "sha256:3eedef0719639892dc263bed7adfc00821544388e3d86a6fa31d82f936a6b613"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.18.7"
+            "version": "==1.18.26"
         },
         "botocore": {
             "hashes": [
-                "sha256:34c8b151a25616ed7791218f6d7780c3a97725fe3ceeaa28085b345a8513af6e",
-                "sha256:dcf399d21170bb899e00d2a693bddcc79e61471fbfead8500a65578700a3190a"
+                "sha256:37f77bf5f72c86d9b5f38e107c3822da66dbf0ef123768a6e80a58590c2796bf",
+                "sha256:911246faac450e13a3ef0e81993dd9bd9c282a7c0f4546bfe8cccf9649364cef"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.7"
+            "version": "==1.21.26"
         },
         "cachetools": {
             "hashes": [
@@ -203,11 +225,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1",
-                "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"
+                "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b",
+                "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.3"
+            "version": "==2.0.4"
         },
         "click": {
             "hashes": [
@@ -249,14 +271,6 @@
             ],
             "version": "==3.0.0"
         },
-        "decorator": {
-            "hashes": [
-                "sha256:6e5c199c16f7a9f0e3a61a4a54b3d27e7dad0dbdde92b944426cb20914376323",
-                "sha256:72ecfba4320a893c53f9706bebb2d55c270c1e51a28789361aa93e4a21319ed5"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==5.0.9"
-        },
         "delegator.py": {
             "hashes": [
                 "sha256:814657d96b98a244c479e3d5f6e9e850ac333e85f807d6bc846e72bbb2537806",
@@ -273,18 +287,18 @@
         },
         "distro": {
             "hashes": [
-                "sha256:0e58756ae38fbd8fc3020d54badb8eae17c5b9dcbed388b17bb55b8a5928df92",
-                "sha256:df74eed763e18d10d0da624258524ae80486432cd17392d9c3d96f5e83cd2799"
+                "sha256:83f5e5a09f9c5f68f60173de572930effbcc0287bb84fdc4426cb4168c088424",
+                "sha256:c8713330ab31a034623a9515663ed87696700b55f04556b97c39cd261aa70dc7"
             ],
-            "version": "==1.5.0"
+            "version": "==1.6.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:036dd68c1e8baa422b6b61619b8e02793da2e20f55e69514612de6c080468755",
-                "sha256:7665c04f2df13cc938dc7d9066cddb1f8af62b038bc8b2306848c1b23121865f"
+                "sha256:c012c8be7c442c8309ca8fa0876fef33f5fd977c467be1e1c1c2f721e8ebd73c",
+                "sha256:ea1af050b3e06eb73e4470f704d23007307bc0e87c13e015f6b90460f1407bd3"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.33.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
         },
         "idna": {
             "hashes": [
@@ -317,15 +331,6 @@
             "markers": "python_version >= '2.7'",
             "version": "==0.3.1"
         },
-        "jsonpath-ng": {
-            "hashes": [
-                "sha256:292a93569d74029ba75ac2dc3d3630fc0e17b2df26119a165fa1d498ca47bf65",
-                "sha256:a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567",
-                "sha256:f75b95dbecb8a0f3b86fd2ead21c2b022c3f5770957492b9b6196ecccfeb10aa"
-            ],
-            "index": "pypi",
-            "version": "==1.5.3"
-        },
         "kubernetes": {
             "hashes": [
                 "sha256:1a2472f8b01bc6aa87e3a34781f859bded5a5c8ff791a53d889a8bd6cc550430",
@@ -354,6 +359,7 @@
                 "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83",
                 "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04",
                 "sha256:5c8c163396cc0df3fd151b927e74f6e4acd67160d6c33304e805b84293351d16",
+                "sha256:64812391546a18896adaa86c77c59a4998f33c24788cadc35789e55b727a37f4",
                 "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791",
                 "sha256:6f12e1427285008fd32a6025e38e977d44d6382cf28e7201ed10d6c1698d2a9a",
                 "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51",
@@ -368,6 +374,7 @@
                 "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa",
                 "sha256:bc4313cbeb0e7a416a488d72f9680fffffc645f8a838bd2193809881c67dd106",
                 "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d",
+                "sha256:c1a40c06fd5ba37ad39caa0b3144eb3772e813b5fb5b084198a985431c2f1e8d",
                 "sha256:c47ff7e0a36d4efac9fd692cfa33fbd0636674c102e9e8d9b26e1b93a94e7617",
                 "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4",
                 "sha256:cdaf11d2bd275bf391b5308f86731e5194a21af45fbaaaf1d9e8147b9160ea92",
@@ -387,11 +394,11 @@
         },
         "mako": {
             "hashes": [
-                "sha256:17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab",
-                "sha256:aea166356da44b9b830c8023cd9b557fa856bd8b4035d6de771ca027dfc5cc6e"
+                "sha256:169fa52af22a91900d852e937400e79f535496191c63712e3b9fda5a9bed6fc3",
+                "sha256:6804ee66a7f6a6416910463b00d76a7b25194cd27f1918500c5bd7be2a088a23"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.4"
+            "version": "==1.1.5"
         },
         "markupsafe": {
             "hashes": [
@@ -400,30 +407,50 @@
                 "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
                 "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
                 "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
                 "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
                 "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
+                "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
+                "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
                 "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38",
+                "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
                 "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
                 "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
                 "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
                 "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
                 "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
                 "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
+                "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
                 "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
                 "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
                 "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
                 "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
                 "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
                 "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
                 "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
                 "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
                 "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
                 "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
                 "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
                 "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
                 "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145",
                 "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
+                "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
                 "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
+                "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
+                "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
                 "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
                 "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
                 "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
@@ -512,13 +539,6 @@
                 "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
             ],
             "version": "==4.8.0"
-        },
-        "ply": {
-            "hashes": [
-                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
-                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
-            ],
-            "version": "==3.11"
         },
         "prometheus-client": {
             "hashes": [
@@ -677,10 +697,11 @@
         },
         "python-json-logger": {
             "hashes": [
-                "sha256:f26eea7898db40609563bed0a7ca11af12e2a79858632706d835a0f961b7d398"
+                "sha256:202a4f29901a4b8002a6d1b958407eeb2dd1d83c18b18b816f5b64476dde9096",
+                "sha256:99310d148f054e858cd5f4258794ed6777e7ad2c3fd7e1c1b527f1cba4d08420"
             ],
-            "markers": "python_version >= '3.4'",
-            "version": "==2.0.1"
+            "markers": "python_version >= '3.5'",
+            "version": "==2.0.2"
         },
         "python-string-utils": {
             "hashes": [
@@ -737,7 +758,7 @@
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
                 "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==2.26.0"
         },
         "requests-oauthlib": {
@@ -760,16 +781,16 @@
                 "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2",
                 "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_version >= '3.5' and python_version < '4'",
             "version": "==4.7.2"
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:106bc8d6dc6a0ff7c9196a47570432036f41d556b779c6b4e618085f57e39e67",
-                "sha256:ffb9b703853e9e8b7861606dfdab1026cf02505bade0653d1880f4b2db47f815"
+                "sha256:02f0ed93e98ea32498d25a2952635bbd9fabd553599b8ad67724b4ac88dd8f6c",
+                "sha256:aa1a5b8041bab0d0e8c514949fa8e11b02653061dcbc68365c820b263f8c6ec7"
             ],
             "markers": "python_version >= '3'",
-            "version": "==0.17.10"
+            "version": "==0.17.13"
         },
         "ruamel.yaml.clib": {
             "hashes": [
@@ -816,10 +837,10 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:5210a712dd57d88d225c1fc3fe3a3626fee493637bcd54e204826cf04b8d769c",
-                "sha256:6864dcb6f7dec692635e5518c2a5c80010adf673c70340817f1a1b713d65bb41"
+                "sha256:ebe99144fa9618d4b0e7617e7929b75acd905d258c3c779edcd34c0adfffe26c",
+                "sha256:f33d34c886d0ba24c75ea8885a8b3a172358853c7cbde05979fc99c29ef7bc52"
             ],
-            "version": "==1.3.0"
+            "version": "==1.3.1"
         },
         "six": {
             "hashes": [
@@ -920,11 +941,11 @@
         },
         "thoth-storages": {
             "hashes": [
-                "sha256:3e985a73d56ec6a6d0c2652da5a926d426cefc03a368627992fb725400ceb219",
-                "sha256:7d87fd91ee883ea18169ed96237779f4f7cb2399b21bf587d5b3e3107c77487a"
+                "sha256:34de7ee40f661ebe8492aa6d1083227a2e030c3afb7e699cbccbd6f13c53bf39",
+                "sha256:417c10194a50059bae16fc06f328173377bf8d1611bde5e708c0bbca3cd8b62c"
             ],
             "index": "pypi",
-            "version": "==0.54.0"
+            "version": "==0.55.0"
         },
         "toml": {
             "hashes": [
@@ -944,10 +965,11 @@
         },
         "tzlocal": {
             "hashes": [
-                "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44",
-                "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"
+                "sha256:c736f2540713deb5938d789ca7c3fc25391e9a20803f05b60ec64987cf086559",
+                "sha256:f4e6e36db50499e0d92f79b67361041f048e2609d166e93456b50746dc4aef12"
             ],
-            "version": "==2.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0"
         },
         "urllib3": {
             "hashes": [
@@ -966,11 +988,11 @@
         },
         "websocket-client": {
             "hashes": [
-                "sha256:b68e4959d704768fa20e35c9d508c8dc2bbc041fd8d267c0d7345cffe2824568",
-                "sha256:e5c333bfa9fa739538b652b6f8c8fc2559f1d364243c8a689d7c0e1d41c2e611"
+                "sha256:0133d2f784858e59959ce82ddac316634229da55b498aac311f1620567a710ec",
+                "sha256:8dfb715d8a992f5712fff8c843adae94e22b22a99b2c5e6b0ec4a1a981cc4e0d"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.1.0"
+            "version": "==1.2.1"
         },
         "yarl": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -321,7 +321,7 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.0"
         },
         "jsonformatter": {
@@ -674,7 +674,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "python-dateutil": {
@@ -682,7 +682,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "python-editor": {
@@ -816,7 +816,7 @@
                 "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
                 "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
             ],
-            "markers": "python_version < '3.10' and platform_python_implementation == 'CPython'",
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.10'",
             "version": "==0.2.6"
         },
         "s3transfer": {
@@ -847,7 +847,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "sqlalchemy": {
@@ -952,7 +952,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "typing-extensions": {
@@ -1119,7 +1119,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -1135,7 +1135,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "typing-extensions": {

--- a/config/thoth.yaml
+++ b/config/thoth.yaml
@@ -1,6 +1,0 @@
----
-tensorflow:
-  triggers:
-    - url: "{TENSORFLOW_RELEASE_API}/tensorflow/release/{package_version}"
-      tls_verify: false
-    - url: "http://package-releases.thoth.ultrahook.com"

--- a/producer.py
+++ b/producer.py
@@ -19,7 +19,6 @@
 
 import logging
 import asyncio
-from typing import Optional
 from typing import List
 
 import os
@@ -59,7 +58,7 @@ _THOTH_DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
 _THOTH_METRICS_PUSHGATEWAY_URL = os.getenv("PROMETHEUS_PUSHGATEWAY_URL")
 # Number of concurrent requests to obtain new releases information. Note if the chunk size is too large,
 # the process can reach too many open sockets.
-_CHUNK_SIZE = os.getenv("THOTH_PACKAGE_RELEASES_CHUNK_SIZE", 256)
+_CHUNK_SIZE = int(os.getenv("THOTH_PACKAGE_RELEASES_CHUNK_SIZE", 256))
 
 COMPONENT_NAME = "thoth-package-releases-job"
 
@@ -213,7 +212,7 @@ def _do_package_releases_update(
 def package_releases_update(
     *,
     graph: GraphDatabase,
-    package_names: Optional[List[str]] = None,
+    package_names: List[str],
 ) -> int:
     """Check for updates of packages, notify about updates if configured so."""
     sources = []

--- a/producer.py
+++ b/producer.py
@@ -116,7 +116,7 @@ async def _package_releases_worker(
         )
         return 0
     except Exception as exc:
-        _LOGGER.exception(
+        _LOGGER.warning(
             "Failed to retrieve package versions for %r: %s",
             package_name,
             str(exc),
@@ -233,7 +233,7 @@ def package_releases_update(
         use_package_names = package_names
         if not only_if_package_seen:
             try:
-                package_index.get_packages()
+                use_package_names = list(package_index.get_packages())
             except Exception as exc:
                 _LOGGER.exception(
                     "Failed to obtain package names listing from %r, skipping: %s",

--- a/producer.py
+++ b/producer.py
@@ -195,12 +195,13 @@ def _do_package_releases_update(
 
     result = 0
     for i in range(0, len(package_names), _CHUNK_SIZE):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
         group = asyncio.gather(
             *(
                 _package_releases_worker(graph, async_package_index, pn)
                 for pn in package_names[i : i + _CHUNK_SIZE]
-            )
+            ),
+            loop=loop,
         )
         results = loop.run_until_complete(group)
         result += sum(results)

--- a/producer.py
+++ b/producer.py
@@ -19,6 +19,7 @@
 
 import logging
 import asyncio
+import random
 from typing import List
 
 import os
@@ -288,6 +289,8 @@ def main(
     # An optimization - we don't need to iterate over a large set present on index.
     # Check only packages known to Thoth based on index configuration.
     package_names = graph.get_python_package_version_entities_names_all()
+    # Randomize the list to randomize access on eventual kills.
+    random.shuffle(package_names)
 
     package_releases_messages_sent = package_releases_update(
         graph=graph,

--- a/producer.py
+++ b/producer.py
@@ -18,6 +18,7 @@
 """Check for new releases on Python index and mark new packages in the graph database."""
 
 import logging
+import asyncio
 from typing import Optional
 from typing import List
 
@@ -41,6 +42,7 @@ from thoth.messaging.package_releases import MessageContents as PackageReleasedC
 from prometheus_client import CollectorRegistry, Gauge, Counter, push_to_gateway
 
 from thoth.python import Source
+from thoth.python import AIOSource
 from thoth.python.exceptions import NotFoundError
 
 init_logging()
@@ -55,6 +57,9 @@ _LOGGER.info("Thoth-package-releases-job-producer v%s", __service_version__)
 
 _THOTH_DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
 _THOTH_METRICS_PUSHGATEWAY_URL = os.getenv("PROMETHEUS_PUSHGATEWAY_URL")
+# Number of concurrent requests to obtain new releases information. Note if the chunk size is too large,
+# the process can reach too many open sockets.
+_CHUNK_SIZE = os.getenv("THOTH_PACKAGE_RELEASES_CHUNK_SIZE", 256)
 
 COMPONENT_NAME = "thoth-package-releases-job"
 
@@ -96,6 +101,114 @@ def _print_version(ctx, _, value) -> None:
     ctx.exit()
 
 
+async def _package_releases_worker(
+    graph: GraphDatabase, package_index: AIOSource, package_name: str
+) -> int:
+    """Async handling of new package releases checks."""
+    try:
+        package_versions = await package_index.get_package_versions(package_name)
+    except NotFoundError as exc:
+        _LOGGER.debug(
+            "No versions found for package %r on %r: %s",
+            package_name,
+            package_index.url,
+            str(exc),
+        )
+        return 0
+    except Exception as exc:
+        _LOGGER.exception(
+            "Failed to retrieve package versions for %r: %s",
+            package_name,
+            str(exc),
+        )
+        return 0
+
+    package_releases_messages_sent = 0
+    async for package_version in package_versions:
+        added = graph.create_python_package_version_entity(
+            package_name,
+            package_version,
+            package_index.url,
+        )
+
+        if added is None:
+            _LOGGER.debug(
+                "Package %r in version %r hosted on %r was not added - it was not previously seen",
+                package_name,
+                package_version,
+                package_index.url,
+            )
+            continue
+
+        existed = added[1]
+        if not existed:
+            _LOGGER.info(
+                "New release of package %r in version %r hosted on %r added",
+                package_name,
+                package_version,
+                package_index.url,
+            )
+
+            producer.publish_to_topic(
+                p,
+                package_released_message,
+                PackageReleasedContent(
+                    package_name=package_name,
+                    package_version=package_version,
+                    index_url=package_index.url,
+                    component_name=COMPONENT_NAME,
+                    service_version=__service_version__,
+                ),
+            )
+
+            _LOGGER.debug(
+                "Package %r in version %r hosted on %r added to list to be sent as Kafka message %r",
+                package_name,
+                package_version,
+                package_index.url,
+                package_released_message.topic_name,
+            )
+            package_releases_messages_sent += 1
+        else:
+            _LOGGER.debug(
+                "Release of %r in version %r hosted on %r already present",
+                package_name,
+                package_version,
+                package_index.url,
+            )
+
+    return package_releases_messages_sent
+
+
+def _do_package_releases_update(
+    graph: GraphDatabase, package_index: Source, package_names: List[str]
+) -> int:
+    """Do the actual package releases gathering for a specific Python package index."""
+    # From now on, we will use async.
+    async_package_index = AIOSource(
+        url=package_index.url,
+        warehouse_api_url=package_index.warehouse_api_url,
+        verify_ssl=package_index.verify_ssl,
+        name=package_index.name,
+        warehouse=package_index.warehouse,
+    )
+
+    result = 0
+    for i in range(0, len(package_names), _CHUNK_SIZE):
+        loop = asyncio.get_event_loop()
+        group = asyncio.gather(
+            *(
+                _package_releases_worker(graph, async_package_index, pn)
+                for pn in package_names[i : i + _CHUNK_SIZE]
+            )
+        )
+        results = loop.run_until_complete(group)
+        result += sum(results)
+        loop.close()
+
+    return result
+
+
 def package_releases_update(
     *,
     graph: GraphDatabase,
@@ -116,78 +229,23 @@ def package_releases_update(
 
     for package_index, only_if_package_seen in sources:
         _LOGGER.info("Checking index %r for new package releases", package_index.url)
-        for package_name in package_names or package_index.get_packages():
+        use_package_names = package_names
+        if not only_if_package_seen:
             try:
-                package_versions = package_index.get_package_versions(package_name)
-            except NotFoundError as exc:
-                _LOGGER.debug(
-                    "No versions found for package %r on %r: %s",
-                    package_name,
-                    package_index.url,
-                    str(exc),
-                )
-                continue
+                package_index.get_packages()
             except Exception as exc:
                 _LOGGER.exception(
-                    "Failed to retrieve package versions for %r: %s",
-                    package_name,
+                    "Failed to obtain package names listing from %r, skipping: %s",
+                    package_index.url,
                     str(exc),
                 )
                 continue
 
-            for package_version in package_versions:
-                added = graph.create_python_package_version_entity(
-                    package_name,
-                    package_version,
-                    package_index.url,
-                    only_if_package_seen=only_if_package_seen,
-                )
-
-                if added is None:
-                    _LOGGER.debug(
-                        "Package %r in version %r hosted on %r was not added - it was not previously seen",
-                        package_name,
-                        package_version,
-                        package_index.url,
-                    )
-                    continue
-
-                existed = added[1]
-                if not existed:
-                    _LOGGER.info(
-                        "New release of package %r in version %r hosted on %r added",
-                        package_name,
-                        package_version,
-                        package_index.url,
-                    )
-
-                    producer.publish_to_topic(
-                        p,
-                        package_released_message,
-                        PackageReleasedContent(
-                            package_name=package_name,
-                            package_version=package_version,
-                            index_url=package_index.url,
-                            component_name=COMPONENT_NAME,
-                            service_version=__service_version__,
-                        ),
-                    )
-
-                    _LOGGER.debug(
-                        "Package %r in version %r hosted on %r added to list to be sent as Kafka message %r",
-                        package_name,
-                        package_version,
-                        package_index.url,
-                        package_released_message.topic_name,
-                    )
-                    package_releases_messages_sent += 1
-                else:
-                    _LOGGER.debug(
-                        "Release of %r in version %r hosted on %r already present",
-                        package_name,
-                        package_version,
-                        package_index.url,
-                    )
+        package_releases_messages_sent += _do_package_releases_update(
+            graph,
+            package_index,
+            use_package_names,
+        )
 
     p.flush()
     return package_releases_messages_sent


### PR DESCRIPTION
## Related Issues and Dependencies

Closes: https://github.com/thoth-station/package-releases-job/issues/581
Closes: https://github.com/thoth-station/package-releases-job/issues/531
Closes: https://github.com/thoth-station/package-releases-job/issues/582

## This introduces a breaking change

- [x] No


Optimize retrieval of new releases by rewriting the logic into asyncio. To bypass "too many open files" issue, deployment can configure chunk size that will be used for concurrent requests.